### PR TITLE
Some speedups

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,7 +55,7 @@ write = function(input_path, name, contents, output_directory, ext) {
 
 usage = 'Usage:\n  coffeecup [options] path/to/template.coffee';
 
-switches = [['-j', '--js', 'compile template to js function (template + embedded renderer)'], ['-b', '--bare', 'use with -j to compile template to js (template only)'], ['-c', '--core', 'use with -j to compile renderer to js (renderer only)'], ['-n', '--namespace [name]', 'global object holding the templates (default: "templates")'], ['-w', '--watch', 'watch templates for changes, and recompile'], ['-o', '--output [dir]', 'set the directory for compiled html'], ['-p', '--print', 'print the compiled html to stdout'], ['-f', '--format', 'apply line breaks and indentation to html output'], ['-u', '--utils', 'add helper locals (currently only "render")'], ['-v', '--version', 'display coffeecup version'], ['-h', '--help', 'display this help message']];
+switches = [['-j', '--js', 'compile template to js function (template + embedded renderer)'], ['-b', '--bare', 'use with -j to compile template to js (template only)'], ['-c', '--core', 'use with -j to compile renderer to js (renderer only)'], ['-n', '--namespace [name]', 'global object holding the templates (default: "templates")'], ['-w', '--watch', 'watch templates for changes, and recompile'], ['-o', '--output [dir]', 'set the directory for compiled html'], ['-p', '--print', 'print the compiled html to stdout'], ['-f', '--format', 'apply line breaks and indentation to html output'], ['-u', '--utils', 'add helper locals (currently only "render")'], ['-z', '--optimize', 'optimize resulting JS'], ['-v', '--version', 'display coffeecup version'], ['-h', '--help', 'display this help message']];
 
 this.run = function() {
   var args, file, parser;

--- a/lib/coffeecup.js
+++ b/lib/coffeecup.js
@@ -88,7 +88,7 @@ skeleton = function(data) {
       if (data.autoescape) {
         return h(txt);
       } else {
-        return String(txt);
+        return txt.toString();
       }
     },
     tabs: 0,
@@ -226,7 +226,7 @@ skeleton = function(data) {
     return temp_buffer.join('');
   };
   h = function(txt) {
-    return String(txt).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    return txt.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   };
   doctype = function(type) {
     if (type == null) type = 'default';
@@ -234,7 +234,7 @@ skeleton = function(data) {
     if (data.format) return text('\n');
   };
   text = function(txt) {
-    __cc.buffer.push(String(txt));
+    __cc.buffer.push(txt.toString());
     return null;
   };
   comment = function(cmt) {
@@ -266,7 +266,7 @@ skeleton = function(data) {
   return null;
 };
 
-skeleton = String(skeleton).replace(/function\s*\(.*\)\s*\{/, '').replace(/return null;\s*\}$/, '');
+skeleton = skeleton.toString().replace(/function\s*\(.*\)\s*\{/, '').replace(/return null;\s*\}$/, '');
 
 skeleton = coffeescript_helpers + skeleton;
 
@@ -274,7 +274,7 @@ coffeecup.compile = function(template, options) {
   var code, hardcoded_locals, k, t, tag_functions, tags_used, v, _i, _j, _len, _len2, _ref, _ref2;
   if (options == null) options = {};
   if (typeof template === 'function') {
-    template = String(template);
+    template = template.toString();
   } else if (typeof template === 'string' && (coffee != null)) {
     template = coffee.compile(template, {
       bare: true

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,7 +11,7 @@ exports.setup = function(cc) {
   return coffeecup = cc;
 };
 
-skeleton = 'var __cc = {\n  buffer: \'\'\n};\nvar text = function(txt) {\n  if (typeof txt === \'string\' || txt instanceof String) {\n    __cc.buffer += txt;\n  } else if (typeof txt === \'number\' || txt instanceof Number) {\n    __cc.buffer += String(txt);\n  }\n};\nvar h = function(txt) {\n  var escaped;\n  if (typeof txt === \'string\' || txt instanceof String) {\n    escaped = txt.replace(/&/g, \'&amp;\')\n      .replace(/</g, \'&lt;\')\n      .replace(/>/g, \'&gt;\')\n      .replace(/"/g, \'&quot;\');\n  } else {\n    escaped = txt;\n  }\n  return escaped;\n};\nvar yield = function(f) {\n  var temp_buffer = \'\';\n  var old_buffer = __cc.buffer;\n  __cc.buffer = temp_buffer;\n  f();\n  temp_buffer = __cc.buffer;\n  __cc.buffer = old_buffer;\n  return temp_buffer;\n};\n';
+skeleton = 'var __cc = {\n  buffer: \'\'\n};\nvar text = function(txt) {\n  if (typeof txt === \'string\' || txt instanceof String) {\n    __cc.buffer += txt;\n  } else if (typeof txt === \'number\' || txt instanceof Number) {\n    __cc.buffer += txt.toString();\n  }\n};\nvar h = function(txt) {\n  var escaped;\n  if (typeof txt === \'string\' || txt instanceof String) {\n    escaped = txt.replace(/&/g, \'&amp;\')\n      .replace(/</g, \'&lt;\')\n      .replace(/>/g, \'&gt;\')\n      .replace(/"/g, \'&quot;\');\n  } else {\n    escaped = txt;\n  }\n  return escaped;\n};\nvar yield = function(f) {\n  var temp_buffer = \'\';\n  var old_buffer = __cc.buffer;\n  __cc.buffer = temp_buffer;\n  f();\n  temp_buffer = __cc.buffer;\n  __cc.buffer = old_buffer;\n  return temp_buffer;\n};\n';
 
 call_bound_func = function(func) {
   return ['call', ['dot', func, 'call'], [['name', 'data']]];
@@ -41,7 +41,7 @@ Code = (function() {
     if (this.block != null) {
       return this.block.flush();
     } else {
-      this.nodes.push(this.call(['string', this.line]));
+      this.merge_text(['string', this.line]);
       return this.line = '';
     }
   };
@@ -71,8 +71,28 @@ Code = (function() {
     if (this.block != null) {
       return this.block.push(node);
     } else {
-      return this.nodes.push(this.call(node));
+      return this.merge_text(node);
     }
+  };
+
+  Code.prototype.merge_text = function(arg) {
+    var l, ok, oldArg, prev, _ref2, _ref3;
+    if (arg[0] === 'binary' && arg[1] === '+') {
+      this.merge_text(arg[2]);
+      arg = arg[3];
+    }
+    if (l = this.nodes.length) {
+      prev = this.nodes[l - 1];
+      if (prev[0] === 'stat' && prev[1][0] === 'call' && prev[1][1][0] === 'name' && prev[1][1][1] === 'text') {
+        oldArg = prev[1][2][0];
+        ok = ['string', 'num'];
+        if ((_ref2 = oldArg[0], __indexOf.call(ok, _ref2) >= 0) && (_ref3 = arg[0], __indexOf.call(ok, _ref3) >= 0)) {
+          prev[1][2][0] = ['string', oldArg[1] + arg[1]];
+          return;
+        }
+      }
+    }
+    return this.nodes.push(this.call(arg));
   };
 
   Code.prototype.get_nodes = function() {
@@ -100,7 +120,7 @@ exports.compile = function(source, hardcoded_locals, options) {
       if (name === 'doctype') {
         code = new Code(w.parent());
         if (args.length > 0) {
-          doctype = String(args[0][1]);
+          doctype = args[0][1].toString();
           if (doctype in coffeecup.doctypes) {
             code.append(coffeecup.doctypes[doctype]);
           } else {

--- a/optimized_bench.coffee
+++ b/optimized_bench.coffee
@@ -1,0 +1,49 @@
+#!/usr/bin/env coffee
+
+coffeecup = require './src/coffeecup'
+log = console.log
+
+data =
+  title: 'test'
+  inspired: no
+  users: [
+    {email: 'house@gmail.com', name: 'house'}
+    {email: 'cuddy@gmail.com', name: 'cuddy'}
+    {email: 'wilson@gmail.com', name: 'wilson'}
+  ]
+
+coffeecup_template = ->
+  doctype 5
+  html lang: 'en', ->
+    head ->
+      meta charset: 'utf-8'
+      title @title
+      style '''
+        body {font-family: "sans-serif"}
+        section, header {display: block}
+      '''
+    body ->
+      section ->
+        header ->
+          h1 @title
+        if @inspired
+          p 'Create a witty example'
+        else
+          p 'Go meta'
+        ul ->
+          for user in @users
+            li user.name
+            li -> a href: "mailto:#{user.email}", -> user.email
+
+coffeecup_compiled_template = coffeecup.compile coffeecup_template
+
+coffeecup_optimized_template = coffeecup.compile coffeecup_template, optimize: yes
+
+benchmark = (title, code) ->
+  start = new Date
+  for i in [1..100000]
+    code()
+  log "#{title}: #{new Date - start} ms"
+
+benchmark 'coffeecup (precompiled)', -> coffeecup_compiled_template data
+benchmark 'coffeecup (precompiled, optimized)', -> coffeecup_optimized_template data

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -58,6 +58,7 @@ switches = [
   ['-p', '--print', 'print the compiled html to stdout']
   ['-f', '--format', 'apply line breaks and indentation to html output']
   ['-u', '--utils', 'add helper locals (currently only "render")']
+  ['-z', '--optimize', 'optimize resulting JS']
   ['-v', '--version', 'display coffeecup version']
   ['-h', '--help', 'display this help message']
 ]

--- a/src/coffeecup.coffee
+++ b/src/coffeecup.coffee
@@ -124,7 +124,7 @@ skeleton = (data = {}) ->
     buffer: []
 
     esc: (txt) ->
-      if data.autoescape then h(txt) else String(txt)
+      if data.autoescape then h(txt) else txt.toString()
 
     tabs: 0
 
@@ -238,7 +238,7 @@ skeleton = (data = {}) ->
     temp_buffer.join ''
 
   h = (txt) ->
-    String(txt).replace(/&/g, '&amp;')
+    txt.toString().replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
@@ -248,7 +248,7 @@ skeleton = (data = {}) ->
     text '\n' if data.format
 
   text = (txt) ->
-    __cc.buffer.push String(txt)
+    __cc.buffer.push txt.toString()
     null
 
   comment = (cmt) ->
@@ -284,7 +284,7 @@ skeleton = (data = {}) ->
 
 # Stringify the skeleton and unwrap it from its enclosing `function(){}`, then
 # add the CoffeeScript helpers.
-skeleton = String(skeleton)
+skeleton = skeleton.toString()
   .replace(/function\s*\(.*\)\s*\{/, '')
   .replace(/return null;\s*\}$/, '')
 
@@ -294,7 +294,7 @@ skeleton = coffeescript_helpers + skeleton
 coffeecup.compile = (template, options = {}) ->
   # The template can be provided as either a function or a CoffeeScript string
   # (in the latter case, the CoffeeScript compiler must be available).
-  if typeof template is 'function' then template = String(template)
+  if typeof template is 'function' then template = template.toString()
   else if typeof template is 'string' and coffee?
     template = coffee.compile template, bare: yes
     template = "function(){#{template}}"

--- a/src/compiler.coffee
+++ b/src/compiler.coffee
@@ -15,7 +15,7 @@ skeleton = '''
     if (typeof txt === 'string' || txt instanceof String) {
       __cc.buffer += txt;
     } else if (typeof txt === 'number' || txt instanceof Number) {
-      __cc.buffer += String(txt);
+      __cc.buffer += txt.toString();
     }
   };
   var h = function(txt) {
@@ -156,7 +156,7 @@ exports.compile = (source, hardcoded_locals, options) ->
       if name is 'doctype'
         code = new Code w.parent()
         if args.length > 0
-          doctype = String(args[0][1])
+          doctype = args[0][1].toString()
           if doctype of coffeecup.doctypes
             code.append coffeecup.doctypes[doctype]
           else

--- a/test_optimized.coffee
+++ b/test_optimized.coffee
@@ -1,5 +1,7 @@
 #!/usr/bin/env coffee
 
+ck = require "./src/coffeecup"
+
 tests =
   'Literal text':
     template: "text 'Just text'"
@@ -53,7 +55,7 @@ tests =
 
   'CoffeeScript helper (string)':
     template: "coffeescript \"alert 'hi'\""
-    expected: "<script>alert('hi');</script>"
+    expected: "<script>\nalert('hi');\n</script>"
 
   'Context vars':
     template: "h1 @foo"


### PR DESCRIPTION
With these changes, you can use -z for the coffeecup executable to get an optimized version, and there's a 10-15% speed increase for the optimized version and 5% for the regular:

Original:

``` bash
$ ./optimized_bench.coffee 
coffeecup (precompiled): 7887 ms
coffeecup (precompiled, optimized): 333 ms
```

Now:

``` bash
 $ ./optimized_bench.coffee 
coffeecup (precompiled): 7442 ms
coffeecup (precompiled, optimized): 291 ms
```

The optimized version now outputs things like

``` javascript
            if (this.inspired) {
              text("<p>Create a witty example</p>");
            } else {
              text("<p>Go meta</p>");
            }

                        text('<a href="mailto:');
                        text(user.email);
                        text('">');
```

instead of

``` javascript
            if (this.inspired) {
              text("<p>");
              text("Create a witty example");
              text("</p>");
            } else {
              text("<p>");
              text("Go meta");
              text("</p>");
            }

                        text('<a href="');
                        text("mailto:" + user.email);
                        text('">');
```

Note that it splits up the string concatenation; it's faster to run `text()` twice than to create a concatenated string which gets concatenated.

There is more room for optimization; the text() calls could be inlined into the array push for example (speed), and there could be a mangling run after optimization (size).

All tests pass. This was fun to write, I learned a lot about JS optimization, especially that what seems faster often isn't :-) (jsperf.com FTW!)
