### PR TITLE
Add Stylus Support

### DIFF
--- a/lib/coffeecup.js
+++ b/lib/coffeecup.js
@@ -78,7 +78,7 @@ coffeecup.tags = merge_elements('regular', 'obsolete', 'void', 'obsolete_void', 
 coffeecup.self_closing = merge_elements('void', 'obsolete_void');
 
 skeleton = function(data) {
-  var coffeescript, comment, doctype, h, ie, tag, text, yield, __cc;
+  var coffeescript, comment, doctype, h, ie, stylus, tag, text, yield, __cc;
   if (data == null) data = {};
   if (data.format == null) data.format = false;
   if (data.autoescape == null) data.autoescape = false;
@@ -256,6 +256,18 @@ skeleton = function(data) {
         return script(param);
     }
   };
+  stylus = function(s) {
+    text('<style>');
+    if (data.format) text('\n');
+    data.stylus.render(s, {
+      compress: !data.format
+    }, function(err, css) {
+      if (err) throw err;
+      return text(css);
+    });
+    text('</style>');
+    if (data.format) return text('\n');
+  };
   ie = function(condition, contents) {
     __cc.indent();
     text("<!--[if " + condition + "]>");
@@ -332,6 +344,9 @@ coffeecup.render = function(template, data, options) {
     data[k] = v;
   }
   if (data.cache == null) data.cache = false;
+  try {
+    data.stylus = require('stylus');
+  } catch (_error) {}
   if (data.optimize && !data.cache) data.optimize = false;
   if (data.cache && (cache[template] != null)) {
     tpl = cache[template];

--- a/lib/coffeecup.js
+++ b/lib/coffeecup.js
@@ -344,9 +344,7 @@ coffeecup.render = function(template, data, options) {
     data[k] = v;
   }
   if (data.cache == null) data.cache = false;
-  try {
-    data.stylus = require('stylus');
-  } catch (_error) {}
+  data.stylus = require('stylus');
   if (data.optimize && !data.cache) data.optimize = false;
   if (data.cache && (cache[template] != null)) {
     tpl = cache[template];

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "ejs": "0.4.3",
     "haml": "0.4.2",
     "mocha": "1.0.0",
-    "should": "0.6.0"
+    "should": "0.6.0",
+    "stylus": "0.25.0"
   },
   "keywords": [
     "template",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "coffee-script": ">= 1.2.0",
     "optparse": ">= 1.0.3",
-    "uglify-js": "*"
+    "uglify-js": "*",
+    "stylus": ">=0.25.0"
   },
   "devDependencies": {
     "jade": "0.13.0",
@@ -19,8 +20,7 @@
     "ejs": "0.4.3",
     "haml": "0.4.2",
     "mocha": "1.0.0",
-    "should": "0.6.0",
-    "stylus": "0.25.0"
+    "should": "0.6.0"
   },
   "keywords": [
     "template",

--- a/src/coffeecup.coffee
+++ b/src/coffeecup.coffee
@@ -368,7 +368,7 @@ cache = {}
 coffeecup.render = (template, data = {}, options = {}) ->
   data[k] = v for k, v of options
   data.cache ?= off
-  try data.stylus = require 'stylus'
+  data.stylus = require 'stylus'
 
   # Do not optimize templates if the cache is disabled, as it will slow
   # everything down considerably.

--- a/src/coffeecup.coffee
+++ b/src/coffeecup.coffee
@@ -271,6 +271,15 @@ skeleton = (data = {}) ->
         param.type = 'text/coffeescript'
         script param
 
+  stylus = (s) ->
+    text '<style>'
+    text '\n' if data.format
+    data.stylus.render s, {compress: not data.format}, (err, css) ->
+      if err then throw err
+      text css
+    text '</style>'
+    text '\n' if data.format
+
   # Conditional IE comments.
   ie = (condition, contents) ->
     __cc.indent()
@@ -359,6 +368,7 @@ cache = {}
 coffeecup.render = (template, data = {}, options = {}) ->
   data[k] = v for k, v of options
   data.cache ?= off
+  try data.stylus = require 'stylus'
 
   # Do not optimize templates if the cache is disabled, as it will slow
   # everything down considerably.

--- a/test/stylus.coffee
+++ b/test/stylus.coffee
@@ -1,0 +1,14 @@
+cc = require '../lib/coffeecup'
+
+describe 'Stylus', ->
+  describe 'stylus  "html, body\\n  margin: 0"', ->
+    it 'should render <style>html,body{margin:0}\\n</style>', ->
+      s = -> stylus "html, body\n  margin: 0"
+      cc.render(s).should.equal "<style>html,body{margin:0}\n</style>"
+
+describe 'Stylus optimized', ->
+  describe 'stylus  "html, body\\n  margin: 0"', ->
+    it 'should render <style>html,body{margin:0}\\n</style>', ->
+      s = -> stylus "html, body\n  margin: 0"
+      cc.render(s, optimized: true, cache: on)
+        .should.equal "<style>html,body{margin:0}\n</style>"


### PR DESCRIPTION
Adds Stylus (http://learnboost.github.com/stylus/) support to CoffeeCup. It allows you to put Stylus CSS markup in CoffeeCup source, for example:

```
doctype 5
html ->
  head ->
    stylus '''
      body
        margin: 0
        font: 12px Helvetica, Arial, sans-serif
    '''
```

Added stylus to devDependencies in package.json (stylus is only needed if the stylus feature is used -- not sure though, dependencies or devDependencies?).

Based on code in this CoffeeKup fork:
https://github.com/cmikec/coffeekup/commit/bd50744f9b3783244ae6b2d5a9694022400e37bc
