### PR TITLE
fix coffeecup in the browser

### DIFF
--- a/lib/coffeecup.js
+++ b/lib/coffeecup.js
@@ -316,6 +316,9 @@ skeleton = function(data) {
     }
   };
   stylus = function(s) {
+    if (data.stylus == null) {
+      throw new TemplateError('stylus is not available');
+    }
     text('<style>');
     if (data.format) {
       text('\n');
@@ -423,7 +426,9 @@ coffeecup.render = function(template, data, options) {
   if ((_ref = data.cache) == null) {
     data.cache = false;
   }
-  data.stylus = require('stylus');
+  if (!(typeof window !== "undefined" && window !== null)) {
+    data.stylus = require('stylus');
+  }
   if (data.optimize && !data.cache) {
     data.optimize = false;
   }

--- a/lib/coffeecup.js
+++ b/lib/coffeecup.js
@@ -119,15 +119,15 @@ skeleton = function(data) {
       return tag.apply(data, combo);
     },
     render_idclass: function(str) {
-      var c, classes, i, id, _i, _j, _len, _len1, _ref2;
+      var c, classes, i, id, idx, _i, _j, _len, _len1, _ref2;
       classes = [];
       _ref2 = str.split('.');
-      for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        i = _ref2[_i];
-        if (__indexOf.call(i, '#') >= 0) {
-          id = i.replace('#', '');
-        } else {
-          if (i !== '') {
+      for (idx = _i = 0, _len = _ref2.length; _i < _len; idx = ++_i) {
+        i = _ref2[idx];
+        if (i !== '') {
+          if (idx === 0 && i.indexOf('#') === 0) {
+            id = i.slice(1);
+          } else {
             classes.push(i);
           }
         }

--- a/src/coffeecup.coffee
+++ b/src/coffeecup.coffee
@@ -141,11 +141,12 @@ skeleton = (data = {}) ->
     render_idclass: (str) ->
       classes = []
 
-      for i in str.split '.'
-        if '#' in i
-          id = i.replace '#', ''
+      for i, idx in str.split '.' when i isnt ''
+        # look for an id in the first part
+        if idx is 0 and i.indexOf('#') is 0
+          id = i.slice(1)
         else
-          classes.push i unless i is ''
+          classes.push i
 
       text " id=\"#{id}\"" if id
 

--- a/src/coffeecup.coffee
+++ b/src/coffeecup.coffee
@@ -284,6 +284,7 @@ skeleton = (data = {}) ->
         script param
 
   stylus = (s) ->
+    throw new TemplateError('stylus is not available') unless data.stylus?
     text '<style>'
     text '\n' if data.format
     data.stylus.render s, {compress: not data.format}, (err, css) ->
@@ -380,7 +381,9 @@ cache = {}
 coffeecup.render = (template, data = {}, options = {}) ->
   data[k] = v for k, v of options
   data.cache ?= off
-  data.stylus = require 'stylus'
+
+  if not window?
+    data.stylus = require 'stylus'
 
   # Do not optimize templates if the cache is disabled, as it will slow
   # everything down considerably.


### PR DESCRIPTION
I ran into two issues using coffeecup.js in the browser:

first: IE8 improperly rendered ids when using the shortcut syntax, so

```
div '#foo', 'bar'
```

rendered

```
<div class=#foo>bar</div>
```

(this was an existing bug in CoffeeKup... I think it's actually an improper use of CoffeeScript -- it doesn't strings guarantee String to be enumerable). This closes [issue #12](https://github.com/gradus/coffeecup/issues/12).

second: requiring stylus was done without a guard to ensure we're in the node enviroment (or at least one that knows what "require('stylus')" means).  This change might be shortsighted -- open to feedback if it is.

--Bob
