### PR TITLE
Fix link to API reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Please note that even though all examples are given in CoffeeScript, you can als
 
 ## Resources
 
-- [API reference](https://github.com/gradus/coffeekup/blob/master/docs/reference.md)
+- [API reference](https://github.com/gradus/coffeecup/blob/master/docs/reference.md)
 
 - [Issues](https://github.com/gradus/coffeecup/issues)
 


### PR DESCRIPTION
Hi Kris!  Thank you for working on maintaining CoffeeKup/CoffeeCup!

I noticed the link to the API reference in the README was going back to your fork of CoffeeKup instead of to your CoffeeCup, so here's a fix.
