### PR TITLE
Modified Express adapter to support Express 3.x

### DIFF
--- a/lib/coffeecup.js
+++ b/lib/coffeecup.js
@@ -462,27 +462,26 @@ if (typeof window === "undefined" || window === null) {
         return _Class;
 
       })(Error),
-      compile: function(template, data) {
-        var TemplateError, tpl, _ref;
+      compiler: function(path, data, cb) {
+        var _ref;
         if ((_ref = data.hardcode) == null) {
           data.hardcode = {};
         }
         data.hardcode.partial = function() {
           return text(this.partial.apply(this, arguments));
         };
-        TemplateError = this.TemplateError;
-        try {
-          tpl = coffeecup.compile(template, data);
-        } catch (e) {
-          throw new TemplateError("Error compiling " + data.filename + ": " + e.message);
-        }
-        return function() {
-          try {
-            return tpl.apply(null, arguments);
-          } catch (e) {
-            throw new TemplateError("Error rendering " + data.filename + ": " + e.message);
+        return require('fs').readFile(path, 'utf8', function(err, template) {
+          var TemplateError;
+          if (err) {
+            return cb(err);
           }
-        };
+          TemplateError = this.TemplateError;
+          try {
+            return cb(null, coffeecup.render(template, data));
+          } catch (e) {
+            return cb(new TemplateError("Error compiling " + data.filename + ": " + e.message), template);
+          }
+        });
       }
     }
   };


### PR DESCRIPTION
This was a really quick change I made on my side to get Express 3 to run with CoffeeCup. I broke compatibility, but it would be trivial to support the old Express 2 system side-by-side with the new Express 3 system.
