### PR TITLE
Update coffee-script dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/gradus/coffeecup.git"
   },
   "dependencies": {
-    "coffee-script": "1.3.x",
+    "coffee-script": ">=1.3 <2",
     "optparse": "1.0.3",
     "uglify-js": "1.2.6",
     "stylus": "0.27.2"


### PR DESCRIPTION
CoffeeScript was updated to 1.4.0 a couple weeks ago. coffeecup's package.json is locked to 1.3.x. This is just a patch to the package.json to use newer versions of coffee-script. I conservatively excluded 2.x versions but it would also make sense to just set the dependency version to ">=1.3".
