### PR TITLE
reference new tool since the others are down

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Please note that even though all examples are given in CoffeeScript, you can als
 
 ## Tools
 
+- [Haml ▸ HTML ▸ Coffeecup ▸ Javascript ▸ CoffeeScript Converter](https://github.com/mikesmullin/haml-html-coffeecup-javascript-coffeescript-converter) - hosted tool works in your browser.
+
 - [html2coffeekup](https://github.com/brandonbloom/html2coffeekup) - Converts HTML to CoffeeCup templates.
 
 - [htmlkup](https://github.com/colinta/htmlkup) - Another HTML converter, stdin/stdout based.


### PR DESCRIPTION
none of the links found under your README.md for tools > html 2 coffeecup converters were working for me. 

what i really wanted was an online tool i could bookmark and run in my browser. something that would translate haml to coffeecup (moving from rails to node).

so i made this:

http://haml-html-coffeecup-javascript-coffeescript-converter.smullindesign.com/

or, if above doesn't work:

http://mikesmullin.github.com/haml-html-coffeecup-javascript-coffeescript-converter/

since it is hosted by github it shouldn't go down and its easy to fork mirrors.

you may wish to update your readme.md with this all-in-one tool.
