### PR TITLE
List Teacup in Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Please note that even though all examples are given in CoffeeScript, you can als
 - [black-coffee](https://github.com/gradus/black-coffee) - Flatiron and Coffee-Script Template.
 
 - [iron-coffee](https://github.com/twilson63/iron-coffee) - Flatiron and Coffee-Script Template.
+ 
+- [teacup](https://github.com/goodeggs/teacup) - Descendant that preserves lexical scope to avoid dynamic helpers.
 
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Please note that even though all examples are given in CoffeeScript, you can als
 
 - [iron-coffee](https://github.com/twilson63/iron-coffee) - Flatiron and Coffee-Script Template.
  
-- [teacup](https://github.com/goodeggs/teacup) - Descendant that preserves lexical scope to avoid dynamic helpers.
+- [teacup](https://github.com/goodeggs/teacup) - Descendant that preserves locals in lexical scope.
 
 
 ## Compatibility


### PR DESCRIPTION
The loss of lexically scoped variables from templates burned us enough times that we wrote [teacup](https://github.com/goodeggs/teacup) based off @mark-hahn's work on [drykup](https://github.com/mark-hahn/drykup](https://github.com/mark-hahn/drykup).

Mind if I plug teacup in the related projects to attract similarly frustrated users?
